### PR TITLE
Improve browser caching for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 curl -H "Content-Type:application/json" -X GET "https://calendar.kuzyak.in/api/calendar/2023"
 ```
 
+> Ответы кэшируются в браузере и на CDN в течение 180 дней, что снижает количество запросов к серверу.
+
 ### Локальный запуск
 
 ```bash

--- a/src/app/api/calendar/[year]/[month]/[day]/route.ts
+++ b/src/app/api/calendar/[year]/[month]/[day]/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isNotCorrectDay, isNotCorrectMonth, isNotCorrectYear } from '@/helpers/isNotCorrect';
 import { getErrorMessages } from '@/helpers/getErrorMessages';
 import { isWorkingDay } from '@/helpers/isWorkingDay';
-import { CACHE_CONFIG } from '@/config/cache';
-
+import { CACHE_CONFIG, CACHE_CONTROL } from '@/config/cache';
 import { generateStaticParams as generateParams } from '@/utils/generateStaticParams';
 
 export const dynamic = 'force-static';
@@ -50,7 +49,7 @@ export async function GET(req: NextRequest, { params }: { params: { year: string
   }), {
     status: 200,
     headers: {
-      'Cache-Control': `public, s-maxage=${CACHE_CONFIG.DEFAULT_REVALIDATE}, stale-while-revalidate=${CACHE_CONFIG.STALE_WHILE_REVALIDATE}`,
+      'Cache-Control': CACHE_CONTROL,
       'Content-Type': 'application/json',
     },
   });

--- a/src/app/api/calendar/[year]/[month]/route.ts
+++ b/src/app/api/calendar/[year]/[month]/route.ts
@@ -2,7 +2,7 @@ import { generateData } from '@/helpers/generateData';
 import { getErrorMessages } from '@/helpers/getErrorMessages';
 import { isNotCorrectMonth, isNotCorrectYear } from '@/helpers/isNotCorrect';
 import { NextRequest, NextResponse } from 'next/server';
-import { CACHE_CONFIG } from '@/config/cache';
+import { CACHE_CONFIG, CACHE_CONTROL } from '@/config/cache';
 import { generateStaticParams as generateParams } from '@/utils/generateStaticParams';
 
 export const dynamic = 'force-static';
@@ -40,7 +40,7 @@ export async function GET(req: NextRequest, { params }: { params: { year: string
   }), {
     status: 200,
     headers: {
-      'Cache-Control': `public, s-maxage=${CACHE_CONFIG.DEFAULT_REVALIDATE}, stale-while-revalidate=${CACHE_CONFIG.STALE_WHILE_REVALIDATE}`,
+      'Cache-Control': CACHE_CONTROL,
       'Content-Type': 'application/json',
     },
   });

--- a/src/app/api/calendar/[year]/holidays/route.ts
+++ b/src/app/api/calendar/[year]/holidays/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { generateData } from '@/helpers/generateData';
 import { isNotCorrectYear } from '@/helpers/isNotCorrect';
 import { getErrorMessages } from '@/helpers/getErrorMessages';
-import { CACHE_CONFIG } from '@/config/cache';
+import { CACHE_CONFIG, CACHE_CONTROL } from '@/config/cache';
 
 import { generateStaticParams as generateParams } from '@/utils/generateStaticParams';
 
@@ -48,7 +48,7 @@ export async function GET(req: NextRequest, { params }: { params: { year: string
   }), {
     status: 200,
     headers: {
-      'Cache-Control': `public, s-maxage=${CACHE_CONFIG.DEFAULT_REVALIDATE}, stale-while-revalidate=${CACHE_CONFIG.STALE_WHILE_REVALIDATE}`,
+      'Cache-Control': CACHE_CONTROL,
       'Content-Type': 'application/json',
     },
   });

--- a/src/app/api/calendar/[year]/route.ts
+++ b/src/app/api/calendar/[year]/route.ts
@@ -3,7 +3,7 @@ import { generateData } from '@/helpers/generateData';
 import { isNotCorrectYear } from '@/helpers/isNotCorrect';
 import { getErrorMessages } from '@/helpers/getErrorMessages';
 import { availableYears } from '@/helpers/availableYears';
-import { CACHE_CONFIG } from '@/config/cache';
+import { CACHE_CONFIG, CACHE_CONTROL } from '@/config/cache';
 
 const data = generateData();
 
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest, { params }: { params: { year: string
   }), {
     status: 200,
     headers: {
-      'Cache-Control': `public, s-maxage=${CACHE_CONFIG.DEFAULT_REVALIDATE}, stale-while-revalidate=${CACHE_CONFIG.STALE_WHILE_REVALIDATE}`,
+      'Cache-Control': CACHE_CONTROL,
       'Content-Type': 'application/json',
     },
   });

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { generateData } from '@/helpers/generateData';
+import { CACHE_CONTROL } from '@/config/cache';
 
 const data = generateData();
 
@@ -7,5 +8,11 @@ export async function GET() {
   // Преобразование ключей объекта в массив чисел
   const years = Object.keys(data).map(Number);
 
-  return NextResponse.json({ years, status: 200 });
+  return new NextResponse(JSON.stringify({ years, status: 200 }), {
+    status: 200,
+    headers: {
+      'Cache-Control': CACHE_CONTROL,
+      'Content-Type': 'application/json',
+    },
+  });
 }

--- a/src/config/cache.ts
+++ b/src/config/cache.ts
@@ -3,4 +3,12 @@ export const CACHE_CONFIG = {
   STALE_WHILE_REVALIDATE: 3600, // 1 час
   HOLIDAYS_REVALIDATE: 604800, // тоже 7 дней
   WORKING_DAYS_REVALIDATE: 604800, // тоже 7 дней
+  BROWSER_MAX_AGE: 15552000, // браузерный кэш на 180 дней
 };
+
+export const CACHE_CONTROL = [
+  'public',
+  `max-age=${CACHE_CONFIG.BROWSER_MAX_AGE}`,
+  `s-maxage=${CACHE_CONFIG.DEFAULT_REVALIDATE}`,
+  `stale-while-revalidate=${CACHE_CONFIG.STALE_WHILE_REVALIDATE}`,
+].join(', ');


### PR DESCRIPTION
## Summary
- provide browser cache lifetime constant
- apply new Cache-Control headers across API routes
- document caching in README
- centralize Cache-Control header constant and extend lifetime to 180 days

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684beff33d1083278c798a659110823a